### PR TITLE
removed the requirement of the 'description' field in the Ticket model

### DIFF
--- a/models/Ticket.js
+++ b/models/Ticket.js
@@ -8,7 +8,7 @@ const TicketSchema = new Schema({
   },
   description: {
     type: String,
-    required: true
+
   },
   status: {
     type: String,


### PR DESCRIPTION
This hotfix removes the requirement of the "description" field to create tickets.